### PR TITLE
Document nginx configuration for protected media downloads

### DIFF
--- a/403.html
+++ b/403.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>403 Forbidden</title></head>
+<body><h1>Forbidden</h1></body>
+</html>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,57 @@ Serve the project with nginx or any static HTTP server. The entry point is `inde
 
 Place tracker module files in the `media` directory. Requests to `/media` must include the `X-Player-Token` header matching the `pt` cookie as in the example nginx configuration.
 
+### Example nginx configuration
+
+```nginx
+# /etc/nginx/conf.d/tracker.conf
+map $cookie_pt $pt_set {
+    "" $request_id;       # generate new token when cookie is missing
+    default $cookie_pt;    # reuse existing token
+}
+
+server {
+    listen 80;
+    server_name tracker.example.com;
+
+    root /usr/share/www/tracker;
+    index index.cowbell.html;
+
+    # Basic security and caching headers
+    add_header X-Frame-Options DENY always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy no-referrer-when-downgrade always;
+
+    # Set pt cookie if missing (visible to JavaScript)
+    add_header Set-Cookie "pt=$pt_set; Path=/; SameSite=Lax; Max-Age=86400" always;
+
+    # Static site files
+    location / {
+        try_files $uri $uri/ /index.cowbell.html;
+    }
+
+    # Require matching header and cookie to download modules
+    location /media/ {
+        try_files $uri =404;
+
+        if ($http_x_player_token = "") { return 403; }
+        if ($http_x_player_token != $cookie_pt) { return 403; }
+
+        add_header Cache-Control "no-store" always;
+    }
+
+    # Vendor assets with long-term caching
+    location /vendor/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    # Friendly 403 page
+    error_page 403 /403.html;
+    location = /403.html { internal; }
+}
+```
+
 After cloning the repository, fetch the Cowbell submodule:
 
 ```


### PR DESCRIPTION
## Summary
- document example nginx config with security headers, pt cookie issuance, and protected `/media` access
- add placeholder `403.html` error page referenced by config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c381d8d883308fe98ea59bac7e87