### PR TITLE
Load playlist from server and tidy player layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Generated playlist
+playlist.json
+
+# OS junk
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Winamp-styled web player for tracker modules using [Cowbell](https://github.com/
 
 Serve the project with nginx or any static HTTP server. The entry point is `index.cowbell.html`.
 
-Place tracker module files in the `media` directory. Requests to `/media` must include the `X-Player-Token` header matching the `pt` cookie as in the example nginx configuration.
+Place tracker module files in the `media` directory and run `./generate_playlist.sh` to create a `playlist.json` file listing available tracks. Requests to `/media` must include the `X-Player-Token` header matching the `pt` cookie as in the example nginx configuration.
 
 ### Example nginx configuration
 

--- a/generate_playlist.sh
+++ b/generate_playlist.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+MEDIA_DIR="media"
+OUTPUT="playlist.json"
+
+echo "[" > "$OUTPUT"
+first=true
+for path in "$MEDIA_DIR"/*; do
+  [ ! -f "$path" ] && continue
+  file=$(basename "$path")
+  [ "$file" = ".gitkeep" ] && continue
+  title="${file%.*}"
+  if [ "$first" = true ]; then
+    first=false
+  else
+    printf ',\n' >> "$OUTPUT"
+  fi
+  printf '  {"title": "%s", "file": "%s"}' "$title" "$MEDIA_DIR/$file" >> "$OUTPUT"
+done
+printf '\n]\n' >> "$OUTPUT"

--- a/generate_playlist.sh
+++ b/generate_playlist.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 MEDIA_DIR="media"
 OUTPUT="playlist.json"
 

--- a/generate_playlist.sh
+++ b/generate_playlist.sh
@@ -9,6 +9,7 @@ for path in "$MEDIA_DIR"/*; do
   file=$(basename "$path")
   [ "$file" = ".gitkeep" ] && continue
   title="${file%.*}"
+  title="${title//_/ }"
   if [ "$first" = true ]; then
     first=false
   else

--- a/index.cowbell.html
+++ b/index.cowbell.html
@@ -6,6 +6,9 @@
   <link rel="stylesheet" href="winamp.css" />
   <script src="vendor/cowbell/cowbell/cowbell.js"></script>
   <script src="vendor/cowbell/cowbell/web_audio_player.js"></script>
+  <script src="vendor/cowbell/cowbell/ay_chip/ay_chip.js"></script>
+  <script src="vendor/cowbell/cowbell/ay_chip/psg_player.js"></script>
+  <script src="vendor/cowbell/cowbell/psgplay/psgplay_player.js"></script>
   <script src="vendor/cowbell/cowbell/openmpt/openmpt_player.js"></script>
 </head>
 <body>

--- a/index.cowbell.html
+++ b/index.cowbell.html
@@ -6,9 +6,19 @@
   <link rel="stylesheet" href="winamp.css" />
   <script src="vendor/cowbell/cowbell/cowbell.js"></script>
   <script src="vendor/cowbell/cowbell/web_audio_player.js"></script>
+  <script src="vendor/cowbell/cowbell/audio_player.js"></script>
+  <script src="vendor/cowbell/cowbell/ay_chip/lh4.js"></script>
   <script src="vendor/cowbell/cowbell/ay_chip/ay_chip.js"></script>
   <script src="vendor/cowbell/cowbell/ay_chip/psg_player.js"></script>
+  <script src="vendor/cowbell/cowbell/ay_chip/vtx_player.js"></script>
+  <script src="vendor/cowbell/cowbell/psgplay/libpsgplay.js"></script>
   <script src="vendor/cowbell/cowbell/psgplay/psgplay_player.js"></script>
+  <script src="vendor/cowbell/cowbell/zx_spectrum/stc_player.js"></script>
+  <script src="vendor/cowbell/cowbell/zx_spectrum/pt3_player.js"></script>
+  <script src="vendor/cowbell/cowbell/zx_spectrum/sqt_player.js"></script>
+  <script src="vendor/cowbell/cowbell/jssid.js"></script>
+  <script src="vendor/cowbell/cowbell/asap/asap.js"></script>
+  <script src="vendor/cowbell/cowbell/asap/asap_player.js"></script>
   <script src="vendor/cowbell/cowbell/openmpt/openmpt_player.js"></script>
 </head>
 <body>
@@ -18,16 +28,18 @@
       <span id="time">00:00 / 00:00</span>
     </div>
     <div id="controls">
-      <button id="btn-prev"><img src="img/prev.svg" alt="Prev" /></button>
-      <button id="btn-play"><img src="img/play.svg" alt="Play" /></button>
-      <button id="btn-pause"><img src="img/pause.svg" alt="Pause" /></button>
-      <button id="btn-stop"><img src="img/stop.svg" alt="Stop" /></button>
-      <button id="btn-next"><img src="img/next.svg" alt="Next" /></button>
-      <input type="range" id="progress" min="0" value="0" />
-      <div id="volume-container">
-        <img src="img/volume.svg" alt="Vol" />
-        <input type="range" id="volume" min="0" max="100" value="80" orient="vertical" />
+      <div id="controls-top">
+        <button id="btn-prev"><img src="img/prev.svg" alt="Prev" /></button>
+        <button id="btn-play"><img src="img/play.svg" alt="Play" /></button>
+        <button id="btn-pause"><img src="img/pause.svg" alt="Pause" /></button>
+        <button id="btn-stop"><img src="img/stop.svg" alt="Stop" /></button>
+        <button id="btn-next"><img src="img/next.svg" alt="Next" /></button>
+        <div id="volume-container">
+          <img src="img/volume.svg" alt="Vol" />
+          <input type="range" id="volume" min="0" max="100" value="80" orient="vertical" />
+        </div>
       </div>
+      <input type="range" id="progress" min="0" value="0" />
     </div>
     <ul id="playlist"></ul>
   </div>

--- a/index.cowbell.html
+++ b/index.cowbell.html
@@ -23,7 +23,7 @@
       <input type="range" id="progress" min="0" value="0" />
       <div id="volume-container">
         <img src="img/volume.svg" alt="Vol" />
-        <input type="range" id="volume" min="0" max="100" value="80" />
+        <input type="range" id="volume" min="0" max="100" value="80" orient="vertical" />
       </div>
     </div>
     <ul id="playlist"></ul>

--- a/player.js
+++ b/player.js
@@ -27,9 +27,17 @@ let playlist = [];
 let currentIndex = 0;
 let audio = null;
 let track = null;
-const player = new Cowbell.Player.OpenMPT({
+
+const openmptPlayer = new Cowbell.Player.OpenMPT({
   pathToLibOpenMPT: 'vendor/cowbell/cowbell/openmpt/libopenmpt.js'
 });
+const players = {
+  sndh: new Cowbell.Player.PSGPlay(),
+  psg: new Cowbell.Player.PSG(),
+  mod: openmptPlayer,
+  s3m: openmptPlayer,
+  xm: openmptPlayer
+};
 
 const elements = {
   trackInfo: document.getElementById('track-info'),
@@ -54,7 +62,14 @@ function loadTrack(index) {
   if (audio && !audio.paused) audio.pause();
   if (track && track.close) track.close();
   currentIndex = index;
-    track = new player.Track(playlist[index].file);
+  const file = playlist[index].file;
+  const ext = file.split('.').pop().toLowerCase();
+  const pl = players[ext];
+  if (!pl) {
+    console.error('No player for extension', ext);
+    return;
+  }
+  track = new pl.Track(file);
   audio = track.open();
   audio.volume = elements.volume.value / 100;
   elements.trackInfo.textContent = playlist[index].title;

--- a/player.js
+++ b/player.js
@@ -6,6 +6,22 @@ function getCookie(name) {
 
 const token = getCookie('pt');
 
+// Ensure media requests include token header when required
+if (token) {
+  (function(open, send) {
+    XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+      this._url = url;
+      return open.call(this, method, url, async, user, pass);
+    };
+    XMLHttpRequest.prototype.send = function(body) {
+      if (this._url && this._url.indexOf('media/') !== -1) {
+        this.setRequestHeader('X-Player-Token', token);
+      }
+      return send.call(this, body);
+    };
+  })(XMLHttpRequest.prototype.open, XMLHttpRequest.prototype.send);
+}
+
 let playlist = [];
 
 let currentIndex = 0;
@@ -38,8 +54,7 @@ function loadTrack(index) {
   if (audio && !audio.paused) audio.pause();
   if (track && track.close) track.close();
   currentIndex = index;
-  const options = token ? { headers: { 'X-Player-Token': token } } : {};
-  track = new player.Track(playlist[index].file, options);
+    track = new player.Track(playlist[index].file);
   audio = track.open();
   audio.volume = elements.volume.value / 100;
   elements.trackInfo.textContent = playlist[index].title;

--- a/player.js
+++ b/player.js
@@ -6,10 +6,7 @@ function getCookie(name) {
 
 const token = getCookie('pt');
 
-const playlist = [
-  { title: 'Ambient Power - Vogue', file: 'media/ambpower.mod' },
-  { title: 'Inside Out - Purple Motion', file: 'media/inside_out.s3m' }
-];
+let playlist = [];
 
 let currentIndex = 0;
 let audio = null;
@@ -67,6 +64,17 @@ function updatePlaylistUI() {
   });
 }
 
+function setupPlaylistUI() {
+  elements.playlist.innerHTML = '';
+  playlist.forEach((t, i) => {
+    const li = document.createElement('li');
+    li.textContent = t.title;
+    li.onclick = () => { loadTrack(i); playCurrent(); };
+    elements.playlist.appendChild(li);
+  });
+  updatePlaylistUI();
+}
+
 function playCurrent() {
   if (!audio) loadTrack(currentIndex);
   audio.play();
@@ -93,14 +101,17 @@ function prevTrack() {
   playCurrent();
 }
 
-// Setup playlist UI
-playlist.forEach((t, i) => {
-  const li = document.createElement('li');
-  li.textContent = t.title;
-  li.onclick = () => { loadTrack(i); playCurrent(); };
-  elements.playlist.appendChild(li);
-});
-updatePlaylistUI();
+async function fetchPlaylist() {
+  try {
+    const response = await fetch('playlist.json');
+    playlist = await response.json();
+    setupPlaylistUI();
+    // Load first track but don't autoplay
+    loadTrack(0);
+  } catch (err) {
+    console.error('Failed to load playlist', err);
+  }
+}
 
 // Control handlers
 elements.play.onclick = playCurrent;
@@ -139,6 +150,4 @@ document.addEventListener('keydown', (e) => {
       break;
   }
 });
-
-// Load first track but don't autoplay
-loadTrack(0);
+fetchPlaylist();

--- a/player.js
+++ b/player.js
@@ -38,7 +38,8 @@ function loadTrack(index) {
   if (audio && !audio.paused) audio.pause();
   if (track && track.close) track.close();
   currentIndex = index;
-  track = new player.Track(playlist[index].file, { headers: { 'X-Player-Token': token } });
+  const options = token ? { headers: { 'X-Player-Token': token } } : {};
+  track = new player.Track(playlist[index].file, options);
   audio = track.open();
   audio.volume = elements.volume.value / 100;
   elements.trackInfo.textContent = playlist[index].title;

--- a/player.js
+++ b/player.js
@@ -28,15 +28,27 @@ let currentIndex = 0;
 let audio = null;
 let track = null;
 
+const audioPlayer = new Cowbell.Player.Audio();
 const openmptPlayer = new Cowbell.Player.OpenMPT({
   pathToLibOpenMPT: 'vendor/cowbell/cowbell/openmpt/libopenmpt.js'
 });
 const players = {
-  sndh: new Cowbell.Player.PSGPlay(),
+  mp3: audioPlayer,
+  ogg: audioPlayer,
+  wav: audioPlayer,
   psg: new Cowbell.Player.PSG(),
+  psy: new Cowbell.Player.PSG({ ayFrequency: 2000000, ayMode: 'YM' }),
+  sndh: new Cowbell.Player.PSGPlay(),
+  vtx: new Cowbell.Player.VTX(),
+  stc: new Cowbell.Player.ZXSTC({ stereoMode: 'acb' }),
+  pt3: new Cowbell.Player.ZXPT3({ stereoMode: 'acb' }),
+  sqt: new Cowbell.Player.ZXSQT({ stereoMode: 'acb' }),
+  sid: new Cowbell.Player.JSSID(),
+  sap: new Cowbell.Player.ASAP(),
   mod: openmptPlayer,
   s3m: openmptPlayer,
-  xm: openmptPlayer
+  xm: openmptPlayer,
+  it: openmptPlayer
 };
 
 const elements = {

--- a/winamp.css
+++ b/winamp.css
@@ -41,16 +41,20 @@ body {
   display: flex;
   align-items: center;
   margin-top: 4px;
+  height: 70px;
 }
 
 #volume-container img {
   width: 16px;
   height: 16px;
-  margin-right: 4px;
 }
 
 #volume {
-  width: 80px;
+  writing-mode: bt-lr;
+  -webkit-appearance: slider-vertical;
+  width: 8px;
+  height: 70px;
+  margin-left: 4px;
 }
 #playlist {
   list-style: none;

--- a/winamp.css
+++ b/winamp.css
@@ -19,39 +19,41 @@ body {
 }
 #controls {
   margin-top: 4px;
+}
+#controls-top {
   display: flex;
   align-items: center;
 }
-#controls button {
+#controls-top button {
   background: none;
   border: none;
   margin-right: 2px;
   cursor: pointer;
 }
-#controls button img {
+#controls-top button img {
   width: 20px;
   height: 20px;
 }
 #progress {
-  flex: 1;
-  margin: 0 4px;
+  width: 100%;
+  margin-top: 4px;
 }
 #volume-container {
   display: flex;
+  flex-direction: column;
   align-items: center;
+  margin-left: auto;
 }
-
 #volume-container img {
   width: 16px;
   height: 16px;
+  margin-bottom: 4px;
 }
-
 #volume {
   -webkit-appearance: slider-vertical;
   writing-mode: bt-lr;
   width: 8px;
   height: 70px;
-  margin-left: 4px;
 }
 #playlist {
   list-style: none;

--- a/winamp.css
+++ b/winamp.css
@@ -4,7 +4,7 @@ body {
   color: #fff;
 }
 #player {
-  width: 280px;
+  width: 320px;
   background: #2b2b2b;
   border: 2px solid #000;
   padding: 4px;
@@ -20,7 +20,6 @@ body {
 #controls {
   margin-top: 4px;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
 }
 #controls button {
@@ -34,27 +33,26 @@ body {
   height: 20px;
 }
 #progress {
-  flex: 1 0 100%;
-  margin-top: 4px;
+  flex: 1;
+  margin: 0 4px;
 }
 #volume-container {
-    display: flex;
-    align-items: center;
-    margin-top: 4px;
-  }
+  display: flex;
+  align-items: center;
+}
 
-  #volume-container img {
-    width: 16px;
-    height: 16px;
-  }
+#volume-container img {
+  width: 16px;
+  height: 16px;
+}
 
-  #volume {
-    transform: rotate(-90deg);
-    transform-origin: left center;
-    width: 70px;
-    height: 8px;
-    margin-left: 4px;
-  }
+#volume {
+  -webkit-appearance: slider-vertical;
+  writing-mode: bt-lr;
+  width: 8px;
+  height: 70px;
+  margin-left: 4px;
+}
 #playlist {
   list-style: none;
   padding: 0;

--- a/winamp.css
+++ b/winamp.css
@@ -38,24 +38,23 @@ body {
   margin-top: 4px;
 }
 #volume-container {
-  display: flex;
-  align-items: center;
-  margin-top: 4px;
-  height: 70px;
-}
+    display: flex;
+    align-items: center;
+    margin-top: 4px;
+  }
 
-#volume-container img {
-  width: 16px;
-  height: 16px;
-}
+  #volume-container img {
+    width: 16px;
+    height: 16px;
+  }
 
-#volume {
-  writing-mode: bt-lr;
-  -webkit-appearance: slider-vertical;
-  width: 8px;
-  height: 70px;
-  margin-left: 4px;
-}
+  #volume {
+    transform: rotate(-90deg);
+    transform-origin: left center;
+    width: 70px;
+    height: 8px;
+    margin-left: 4px;
+  }
 #playlist {
   list-style: none;
   padding: 0;

--- a/winamp.css
+++ b/winamp.css
@@ -20,6 +20,7 @@ body {
 #controls {
   margin-top: 4px;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
 }
 #controls button {
@@ -33,13 +34,21 @@ body {
   height: 20px;
 }
 #progress {
-  flex: 1;
+  flex: 1 0 100%;
+  margin-top: 4px;
 }
 #volume-container {
   display: flex;
   align-items: center;
-  margin-left: 4px;
+  margin-top: 4px;
 }
+
+#volume-container img {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+}
+
 #volume {
   width: 80px;
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded playlist with `playlist.json` fetched from the server
- Add shell script to generate playlist.json from media files
- Adjust player CSS to keep progress bar and volume control within bounds
- Document playlist generation and ignore generated file

## Testing
- `./generate_playlist.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899da7a93dc833084e9b1ec34e4f113