### PR TITLE
Refine CSP to support WebAssembly playback

### DIFF
--- a/index.cowbell.html
+++ b/index.cowbell.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self'; media-src 'self'; connect-src 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' blob:; img-src 'self'; media-src 'self'; connect-src 'self'" />
   <title>Tracker Player</title>
   <link rel="stylesheet" href="winamp.css" />
   <script src="vendor/cowbell/cowbell/cowbell.js"></script>


### PR DESCRIPTION
## Summary
- allow inline styles
- permit wasm evaluation and blob scripts for Cowbell players

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b2715308330827e1fa80bc4a696