### PR TITLE
feat: allow inline scripts and document testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,6 @@
   - https://github.com/demozoo/cowbell/blob/main/doc/usage.md
 - Example code for the SDK is available at https://github.com/demozoo/cowbell/tree/main/example
 - Use 2-space indentation and terminate statements with semicolons.
-- No automated test suite is present; running `npm test` will fail because `package.json` is missing. Execute it anyway as a best-effort check.
+- No automated test suite is present, and there is no `package.json`; do not run any `npm` commands.
 - Prefer `rg` (ripgrep) for code search and avoid `ls -R` or `grep -R` to keep operations fast.
-- To preview the player locally, serve the repo root over HTTP (e.g. `python -m http.server`) and open `index.cowbell.html` in a browser.
+- For manual testing, run `./generate_playlist.sh`, then serve the repo root over HTTP (e.g. `python -m http.server`) and verify `index.cowbell.html` loads (for example with `curl -I http://localhost:8000/index.cowbell.html`). The custom nginx configuration from production is not required.

--- a/index.cowbell.html
+++ b/index.cowbell.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' blob:; img-src 'self'; media-src 'self'; connect-src 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' blob:; img-src 'self'; media-src 'self'; connect-src 'self'" />
   <title>Tracker Player</title>
   <link rel="stylesheet" href="winamp.css" />
   <script src="vendor/cowbell/cowbell/cowbell.js"></script>


### PR DESCRIPTION
## Summary
- permit inline `<script>` tags by relaxing CSP with `unsafe-inline`
- describe manual playlist generation and HTTP preview in AGENTS instructions

## Testing
- `./generate_playlist.sh`
- `python -m http.server 8000 &` & `curl -I http://localhost:8000/index.cowbell.html`


------
https://chatgpt.com/codex/tasks/task_e_689a0f34348c833098434b346d0742cc