### PR TITLE
Prevent playlist refresh during playback

### DIFF
--- a/player.js
+++ b/player.js
@@ -469,4 +469,6 @@ document.addEventListener('keydown', (e) => {
   }
 });
 fetchPlaylist();
-setInterval(fetchPlaylist, 30000);
+setInterval(() => {
+  if (!audio || audio.paused) fetchPlaylist();
+}, 30000);


### PR DESCRIPTION
## Summary
- Skip periodic playlist refresh while a track is playing to keep user scrolling stable

## Testing
- `./generate_playlist.sh`
- `python -m http.server` (separate session)
- `curl -I http://localhost:8000/index.cowbell.html`


------
https://chatgpt.com/codex/tasks/task_e_689b334abb2483308607d86f4e70ce74