### PR TITLE
feat: add winamp-style display with analyzer

### DIFF
--- a/index.cowbell.html
+++ b/index.cowbell.html
@@ -25,8 +25,11 @@
 <body>
   <div id="player">
     <div id="display">
-      <span id="track-info">-</span>
-      <span id="time">00:00 / 00:00</span>
+      <div id="time-area">
+        <div id="time">00:00 / 00:00</div>
+        <canvas id="spectrum" width="76" height="15"></canvas>
+      </div>
+      <div id="track-info">-</div>
     </div>
     <div id="controls">
       <div id="controls-top">

--- a/player.js
+++ b/player.js
@@ -117,6 +117,75 @@ const elements = {
   share: document.getElementById('btn-share')
 };
 
+const spectrumCanvas = document.getElementById('spectrum');
+let spectrumCtx = null;
+let spectrumInterval = null;
+let spectrumValues = [];
+
+function drawSpectrum() {
+  if (!spectrumCtx) return;
+  const width = spectrumCanvas.width;
+  const height = spectrumCanvas.height;
+  const barWidth = 3;
+  spectrumCtx.clearRect(0, 0, width, height);
+  for (let i = 0; i < spectrumValues.length; i++) {
+    const val = spectrumValues[i];
+    for (let y = 0; y < val; y++) {
+      let color;
+      if (y < height * 0.33) color = '#33ff33';
+      else if (y < height * 0.66) color = '#ffff33';
+      else color = '#ff3333';
+      spectrumCtx.fillStyle = color;
+      spectrumCtx.fillRect(i * barWidth, height - y, barWidth - 1, 1);
+    }
+  }
+}
+
+function updateSpectrum() {
+  const height = spectrumCanvas.height;
+  for (let i = 0; i < spectrumValues.length; i++) {
+    spectrumValues[i] = Math.random() * height;
+  }
+  drawSpectrum();
+}
+
+function startSpectrum() {
+  if (!spectrumCtx) return;
+  if (!spectrumValues.length) {
+    const width = spectrumCanvas.width;
+    const barWidth = 3;
+    const bars = Math.floor(width / barWidth);
+    spectrumValues = new Array(bars).fill(0);
+  }
+  stopSpectrum();
+  spectrumInterval = setInterval(updateSpectrum, 100);
+}
+
+function stopSpectrum() {
+  if (spectrumInterval) {
+    clearInterval(spectrumInterval);
+    spectrumInterval = null;
+  }
+}
+
+function resetSpectrum() {
+  if (!spectrumCtx) return;
+  stopSpectrum();
+  for (let i = 0; i < spectrumValues.length; i++) {
+    spectrumValues[i] = 0;
+  }
+  drawSpectrum();
+}
+
+if (spectrumCanvas && spectrumCanvas.getContext) {
+  spectrumCtx = spectrumCanvas.getContext('2d');
+  const width = spectrumCanvas.width;
+  const barWidth = 3;
+  const bars = Math.floor(width / barWidth);
+  spectrumValues = new Array(bars).fill(0);
+  drawSpectrum();
+}
+
 if (userPrefs.volume !== undefined) {
   elements.volume.value = userPrefs.volume;
   applyVolume();
@@ -171,6 +240,7 @@ function loadTrack(file) {
   if (index === -1) return false;
   if (audio && !audio.paused) audio.pause();
   if (track && track.close) track.close();
+  resetSpectrum();
   currentFile = file;
   userPrefs.file = file;
   savePrefs();
@@ -283,10 +353,12 @@ function playCurrent() {
     audio.context.resume();
   }
   if (audio) audio.play();
+  startSpectrum();
 }
 
 function pauseCurrent() {
   if (audio) audio.pause();
+  stopSpectrum();
 }
 
 function stopCurrent() {
@@ -294,6 +366,7 @@ function stopCurrent() {
     audio.pause();
     audio.currentTime = 0;
   }
+  resetSpectrum();
 }
 
 function nextTrack() {

--- a/winamp.css
+++ b/winamp.css
@@ -17,12 +17,44 @@ body {
   transform-origin: center;
 }
 #display {
-  background: #000;
-  padding: 2px 4px;
-  font-size: 12px;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  background: linear-gradient(#404040, #2b2b2b);
+  border: 1px solid #000;
+  padding: 3px;
+  font-size: 12px;
+}
+
+#time-area {
+  background: #000;
+  padding: 2px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-right: 4px;
+}
+
+#time {
+  font-family: monospace;
+  color: #00ff00;
+  background: #000;
+}
+
+#spectrum {
+  width: 76px;
+  height: 15px;
+  background: #000;
+  margin-top: 2px;
+  display: block;
+}
+
+#track-info {
+  flex: 1;
+  background: #000;
+  color: #00ff00;
+  padding: 2px 4px;
+  overflow: hidden;
+  white-space: nowrap;
 }
 #controls {
   margin-top: 4px;
@@ -63,7 +95,7 @@ body {
   -webkit-appearance: slider-vertical;
   writing-mode: bt-lr;
   width: 8px;
-  height: 70px;
+  height: 49px;
 }
 #playlist {
   list-style: none;


### PR DESCRIPTION
## Summary
- emulate Winamp-style header layout and palette
- add decorative spectrum analyzer with random colored bars
- animate spectrum only during playback and shrink volume slider

## Testing
- `./generate_playlist.sh`
- `python -m http.server &`
- `curl -I http://localhost:8000/index.cowbell.html`


------
https://chatgpt.com/codex/tasks/task_e_689b363b5968833087fa66e7f8bc9908