### PR TITLE
Defer OpenMPT track cleanup to prevent Wasm errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,8 @@
 - Manual checks are optional: `./tests/test.sh` already covers playlist generation and basic server availability, but you can still run `./generate_playlist.sh` and serve the repo over HTTP if you need to inspect pages manually.
 - When editing audio playback logic (e.g. `player.js`), clean up audio nodes and control playback logic so that only one track plays at a time.
 - Follow Web Audio best practices and general JavaScript best practices, clean up event listeners, and be secure to avoid vulnerabilities.
+- When working with callbacks triggered by underlying libraries, avoid destroying or reinitializing resources synchronously if the library may still access them; defer cleanup or verify the resource is no longer in use.
+- When interfacing with WebAssembly or similar low-level libraries, release temporary allocations after initialization to prevent memory leaks during sequential playback.
+- When finalizing WebAssembly-backed tracks, wait one tick before calling `close()` so that any library-internal callbacks (e.g., implicit `seek` operations) complete without touching freed memory.
+- Avoid triggering additional playback actions (e.g., `seek`) within completion callbacks if the underlying library already handles them; re-entrant calls can touch freed memory.
+- For any code change, evaluate the user experience across common scenarios (sequential playback, manual track switching, stopping, etc.) and ensure behavior remains intuitive.

--- a/player.js
+++ b/player.js
@@ -244,7 +244,10 @@ function cleanupAudio() {
     audio.onended = null;
   }
   if (track && typeof track.close === 'function') {
-    try { track.close(); } catch (e) {}
+    const oldTrack = track;
+    setTimeout(() => {
+      try { oldTrack.close(); } catch (e) {}
+    }, 0);
   }
   if (masterGain && masterGain.context) {
     try { masterGain.disconnect(); } catch (e) {}
@@ -307,8 +310,16 @@ function loadTrack(file) {
     const duration = elements.progress.max || audio.duration || 0;
     elements.time.textContent = formatTime(audio.currentTime) + ' / ' + formatTime(duration);
   };
+  const playedFile = currentFile;
   audio.onended = () => {
-    nextTrack();
+    if (audio && typeof audio.currentTime === 'number') {
+      try { audio.currentTime = 0; } catch (e) {}
+    }
+    setTimeout(() => {
+      if (currentFile === playedFile) {
+        nextTrack();
+      }
+    }, 0);
   };
   updatePlaylistUI();
   return true;


### PR DESCRIPTION
## Summary
- Delay WebAssembly track closure and reset playback position before switching tracks to avoid out-of-bounds memory access after sequential playback
- Clarify agent instructions to wait a tick before calling `close()` on WebAssembly-backed tracks
- Avoid reentrant seeks on `onended` to keep WebAssembly modules stable and document callback-safety guidelines
- Restore Cowbell submodule reference to the original commit

## Testing
- `./tests/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c3cf5b780833093fc88fbc0da7c22