### PR TITLE
Prepare Pages workflow for default index

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: ./generate_playlist.sh
+      - run: cp index.cowbell.html index.html
+      - uses: actions/upload-pages-artifact@v2
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ A Winamp-styled web player for [music modules](https://modarchive.org/index.php)
    ```
 
    Then open [http://localhost:8000/index.cowbell.html](http://localhost:8000/index.cowbell.html) in your browser.
+For public hosting, requests for files under `/media` must include the `X-Player-Token` header that matches the `pt` cookie. The included `nginx.conf` demonstrates one way to enforce this in production:
 
-For public hosting, requests for files under `/media` must include the `X-Player-Token` header that matches the `pt` cookie. See `nginx.conf` for an example configuration.
+1. Copy `nginx.conf` to `/etc/nginx/conf.d/tracker.conf`.
+2. Adjust `server_name` and `root` to match your domain and installation path.
+3. Reload Nginx, e.g. `sudo nginx -s reload`.
+
+When served from GitHub Pages this protection is disabled automatically because custom response headers are not supported.
 
 ## Hotkeys
 

--- a/player.js
+++ b/player.js
@@ -4,7 +4,8 @@ function getCookie(name) {
   return match ? decodeURIComponent(match[2]) : null;
 }
 
-const token = getCookie('pt');
+const isGitHubPages = /\.github\.io$/.test(window.location.hostname);
+const token = isGitHubPages ? null : getCookie('pt');
 
 const storageKey = 'prefs_' + (token || 'default');
 
@@ -23,7 +24,7 @@ function savePrefs() {
 let userPrefs = loadPrefs();
 
 // Ensure media requests include token header when required
-if (token) {
+if (!isGitHubPages && token) {
   (function(open, send) {
     XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
       this._url = url;


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow that generates playlist and copies `index.cowbell.html` to `index.html`
- detect GitHub Pages environment in `player.js` and skip `X-Player-Token` there
- document how to apply `nginx.conf` in production
- enable Pages workflow by removing temporary guard

## Testing
- `./tests/test.sh` (shellcheck and eslint not installed; Playwright tests skipped)


------
https://chatgpt.com/codex/tasks/task_e_68ad73b029d88330aaeae3e421d6ad91