### PR TITLE
Fix Pages deployment artifact path and refresh action guidelines

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -7,7 +7,7 @@ jobs:
   run_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - uses: actions/setup-python@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,11 +20,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - run: ./generate_playlist.sh
       - run: cp index.cowbell.html index.html
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: .
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@
 - Use 2-space indentation and terminate statements with semicolons.
 - Automated tests live under `tests/`. Run `./tests/test.sh` for linting and playlist validation. The same script runs in CI and only executes Playwright when the `CI` environment variable is set; do not install Playwright or browsers locally. There is no `package.json`; do not run any `npm` commands.
 - GitHub Actions run in `.github/workflows/ci_test.yml`. Comment `retest` or `retest please` on a pull request to trigger the workflow
-    again if you have write access.
+-    again if you have write access.
+- When editing or creating GitHub Actions workflows, always pin each action to its latest major release and check for new versions to avoid deprecated actions.
 - Prefer `rg` (ripgrep) for code search and avoid `ls -R` or `grep -R` to keep operations fast.
 - Manual checks are optional: `./tests/test.sh` already covers playlist generation and basic server availability, but you can still run `./generate_playlist.sh` and serve the repo over HTTP if you need to inspect pages manually.
 - When editing audio playback logic (e.g. `player.js`), clean up audio nodes and control playback logic so that only one track plays at a time.


### PR DESCRIPTION
## Summary
- specify repository root when uploading Pages artifact
- clarify agent guidance to always pin and update actions to the latest major versions
- ensure workflows rely on up-to-date actions to avoid deprecations

## Testing
- `./tests/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ad82fad7a88330afa134ef2a3a6289